### PR TITLE
DCL-PROC getting extra P

### DIFF
--- a/rpg/specs/P.js
+++ b/rpg/specs/P.js
@@ -21,7 +21,7 @@ module.exports = {
       prevName = "";
     }
     if (input.endsWith("...")) {
-      prevName = input.substr(0, input.length - 3);
+      prevName = input.substr(7, input.length - 10).trim();
       output.remove = true;
     } else {
       switch (input[24].toUpperCase()) {


### PR DESCRIPTION
The P from the P-spec was not being stripped out when creating the DCL-PROC when the procedure name was long and ended with ...